### PR TITLE
Use C++11 for copy/move ctors

### DIFF
--- a/minijson_reader.hpp
+++ b/minijson_reader.hpp
@@ -46,8 +46,13 @@ class noncopyable
 private:
 
     // C++03 idiom to prevent copy construction and copy assignment
-    noncopyable(const noncopyable&);
-    noncopyable& operator=(const noncopyable&);
+    // C++11 preferred implementation to remove copy ctor
+    noncopyable(const noncopyable&) = delete;
+    noncopyable& operator=(const noncopyable&) = delete;
+    
+    // Consider also move semantic requirements
+    // noncopyable(const noncopyable&&) = delete;
+    // noncopyable& operator=(const noncopyable&&) = delete;
 
 public:
 


### PR DESCRIPTION
added = delete to copy ctor, which also blocks back door friend class access to private ctors.